### PR TITLE
Fix CI test matrix silently testing one HA version for all three

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,18 +15,29 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Explicit (python, ha) pairs instead of a full cross-product: recent Home Assistant
-        # releases require newer Python versions (e.g. 2026.4.0+ needs Python >=3.14.2), so not
-        # every python-version/ha-version combination is installable. Python 3.12 is no longer
-        # tested: HA 2025.4.4 (our oldest tested/supported version, matching hacs.json) already
-        # requires Python >=3.13.
+        # Explicit (python, ha, phacc) triples instead of a full cross-product: recent Home
+        # Assistant releases require newer Python versions (e.g. 2026.4.0+ needs Python
+        # >=3.14.2), so not every python-version/ha-version combination is installable. Python
+        # 3.12 is no longer tested: HA 2025.4.4 (our oldest tested/supported version, matching
+        # hacs.json) already requires Python >=3.13.
+        #
+        # phacc-version pins pytest-homeassistant-custom-component to the release that targets
+        # the matrix's ha-version. This is required, not cosmetic: phacc hard-pins one specific
+        # homeassistant version internally, and its test fixtures only work against that exact
+        # version's internals - installing a different homeassistant version on top (even via
+        # `pip install homeassistant==X --no-deps` after phacc) breaks phacc's fixtures with
+        # ImportErrors. The matching phacc version per ha-version was found by checking each
+        # phacc release's `homeassistant==` pin via the PyPI JSON API.
         include:
           - python-version: "3.13"
             ha-version: "2025.4.4"
+            phacc-version: "0.13.236"
           - python-version: "3.13"
             ha-version: "2026.1.0"
+            phacc-version: "0.13.305"
           - python-version: "3.14"
             ha-version: "2026.7.2"
+            phacc-version: "0.13.346"
 
     steps:
       - uses: actions/checkout@v7.0.1
@@ -39,9 +50,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install homeassistant==${{ matrix.ha-version }}
           pip install -r requirements_test.txt --no-deps
-          pip install pytest pytest-homeassistant-custom-component pytest-cov ruff
+          pip install pytest pytest-cov ruff
+          pip install pytest-homeassistant-custom-component==${{ matrix.phacc-version }}
 
       - name: Run tests with coverage
         run: pytest tests/ -v --cov=custom_components.moving_colors --cov-report=xml --cov-report=term --junitxml=junit.xml


### PR DESCRIPTION
## Summary
- The final unpinned `pip install ... pytest-homeassistant-custom-component ...` step in `.github/workflows/test.yml` pulled in that package's own hard-pinned `homeassistant` version, silently overriding the matrix-selected `homeassistant==<version>` installed earlier in the same step.
- As a result, all three `(python, ha)` matrix entries were actually testing against whatever HA version `pytest-homeassistant-custom-component`'s latest release happens to pin (currently 2026.2.3), not 2025.4.4/2026.1.0/2026.7.2 as the matrix intends.
- Fix: pin `pytest-homeassistant-custom-component` itself per matrix entry to the release that targets the desired `homeassistant` version (found via each release's `homeassistant==` pin on PyPI), instead of installing `homeassistant` separately.

Discovered while reviewing dependabot PR #115 (pytest-homeassistant-custom-component floor bump) and reading the raw CI install logs.

## Test plan
- [ ] CI passes for all three matrix entries (3.13/2025.4.4, 3.13/2026.1.0, 3.14/2026.7.2)
- [ ] Confirm in the job logs that the installed `homeassistant` version now actually matches each matrix entry's `ha-version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)